### PR TITLE
fix what looks like a typo

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -3035,7 +3035,7 @@ Version 2017-01-21"
     (define-key xah-fly-key-map (kbd "<f11>") 'xah-previous-user-buffer)
     (define-key xah-fly-key-map (kbd "<f12>") 'xah-next-user-buffer)
     (define-key xah-fly-key-map (kbd "<C-f11>") 'xah-previous-emacs-buffer)
-    (define-key xah-fly-key-map (kbd "<C-f22>") 'xah-next-emacs-buffer))
+    (define-key xah-fly-key-map (kbd "<C-f12>") 'xah-next-emacs-buffer))
 
   (progn
     ;; set arrow keys in isearch. left/right is backward/forward, up/down is history. press Return to exit


### PR DESCRIPTION
My keyboard doesn't have an F22 key, and my guess is that the binding was supposed to parallel the one two lines above.