### PR TITLE
Open line insert

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -2430,6 +2430,14 @@ Version 2017-01-29"
   (interactive)
   (describe-function major-mode))
 
+(defun open-line-insert ()
+  "Opens a line below, moves the point and activate insert mode. 
+Version 2017-10-08"
+  (interactive)
+  (end-of-line)
+  (newline)
+  (xah-fly-insert-mode-activate))
+
 
 
 (defvar xah--dvorak-to-qwerty-kmap
@@ -3223,7 +3231,7 @@ Version 2017-01-21"
      ("l" . xah-fly-insert-mode-activate-space-before)
      ("m" . xah-backward-left-bracket)
      ("n" . forward-char)
-     ("o" . open-line)
+     ("o" . open-line-insert)
      ("p" . kill-word)
      ("q" . xah-cut-line-or-region)
      ("r" . forward-word)


### PR DESCRIPTION
As a previous Vim user I have grown very fond of the open-line functionality. Upon pressing "o", no matter where the cursor was in the line, a new line was added below the current and the insert mode was activated. 

Currently, I always find myself pressing the combination <s, enter, u> (Dvorak) to achieve the same behavior but using three times more keystrokes. Since "o" was already taken with open-line, I understand if you aren't inclined to this proposal. However, I felt I should tell about its advantages and thought it would be most comfortable if you could try it out immediately. 