### PR TITLE
edit comments for xah-fly--tab-key-map

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -3114,10 +3114,11 @@ Version 2017-01-21"
 
 (xah-fly--define-keys
  (define-prefix-command 'xah-fly--tab-key-map)
- ;; this keymap i've not used. things are here experimentally
- ;; because the tab key is not in a very good ergo position on average keyboards, so 【leader tab ‹somekey›】 probably should not be used much
- ;; currently (2018-03-13), they are commands related to completion or indent, and i basically never use any of these except complete-symbol sometimes
- ;; for average emacs use, the way it is now is probably justified, because most emacs uses don't use these commands. for example, company mode or or just pressing tab in a major mode, takes care of it.
+ ;; This keymap I've not used. things are here experimentally.
+ ;; The TAB key is not in a very good ergonomic position on average keyboards, so 【leader tab ‹somekey›】 probably should not be used much.
+ ;; Currently (2018-03-13), these are commands related to completion or indent, and I basically never use any of these (except sometimes complete-symbol).
+ ;; For average use, the way it is now is probably justified, because most emacs users don't use these commands.
+ ;; To customize this keymap see http://ergoemacs.org/misc/xah-fly-keys_customization.html.
  '(
    ("TAB" . indent-for-tab-command)
 


### PR DESCRIPTION
Just a few readability edits to the comment lines around `xah-fly--tab-key-map`.