### PR TITLE
Fix xah-show-kill-ring, `ttt` after formfeed line

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -533,7 +533,7 @@ Version 2018-10-05"
       (funcall 'fundamental-mode)
       (setq buffer-offer-save t)
       (dolist (x kill-ring )
-        (insert x "\n\u000cttt\n\n"))
+        (insert x "\n\u000c\n\n"))
       (goto-char (point-min)))
     (when (fboundp 'xah-show-formfeed-as-line)
       (xah-show-formfeed-as-line))))


### PR DESCRIPTION
In the `*copy history*` buffer, `ttt` is shown at the end of each formfeed line.

---

### Before:

![emacs_2018-12-23_14-06-17](https://user-images.githubusercontent.com/13420573/50384013-94b5b500-06be-11e9-8e68-25b20e3e7979.png)

### After:

![emacs_2018-12-23_14-06-56](https://user-images.githubusercontent.com/13420573/50384017-a008e080-06be-11e9-8668-2fd00dd9e8e2.png)
