### PR TITLE
Permanent recursive-load fix

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -3209,21 +3209,26 @@ Version 2017-01-29"
 (defcustom xah-fly-key-current-layout nil
   "The current keyboard layout. Use `xah-fly-keys-set-layout' to set the layout.
 If the value is nil, it's automatically set to \"dvorak\"."
-  :type '(choice  (const :tag "AZERTY" 'azerty)
-		  (const :tag "Belgian AZERTY" 'azerty-be)
-		  (const :tag "Colemak" 'colemak)
-		  (const :tag "Colemak Mod-DH" 'colemak-mod-dh)
-		  (const :tag "Dvorak" 'dvorak)
-		  (const :tag "Programmer Dvorak" 'programer-dvorak)
-		  (const :tag "QWERTY" 'qwerty)
-		  (const :tag "Portuguese QWERTY (ABNT)" 'qwerty-abnt)
-		  (const :tag "QWERTZ" 'qwertz)
-		  (const :tag "Workman" 'workman)
-		  (const :tag "Norman" 'norman))
-  :group 'xah-fly-keys)
-(put 'xah-fly-key-current-layout 'custom-set
-     (lambda (_ layout)
-       (xah-fly-keys-set-layout layout)))
+  :type '(choice  (const :tag "AZERTY" azerty)
+		  (const :tag "Belgian AZERTY" azerty-be)
+		  (const :tag "Colemak" colemak)
+		  (const :tag "Colemak Mod-DH" colemak-mod-dh)
+		  (const :tag "Dvorak" dvorak)
+		  (const :tag "Programmer Dvorak" programer-dvorak)
+		  (const :tag "QWERTY" qwerty)
+		  (const :tag "Portuguese QWERTY (ABNT)" qwerty-abnt)
+		  (const :tag "QWERTZ" qwertz)
+		  (const :tag "Workman" workman)
+		  (const :tag "Norman" norman))
+  :group 'xah-fly-keys
+  :set (lambda (@layout-var @new-layout)
+	 ;; Only reload xah-fly-keys if it was already loaded and the new layout is different:
+	 (if (and (featurep 'xah-fly-keys)
+		  (not (eq @new-layout (symbol-value @layout-var))))
+	     (progn
+	       (set @layout-var @new-layout)
+	       (load "xah-fly-keys"))
+	   (set @layout-var @new-layout))))
 (if xah-fly-key-current-layout nil (setq xah-fly-key-current-layout 'dvorak))
 
 (defvar xah-fly--current-layout-kmap nil
@@ -3994,10 +3999,10 @@ For backwards compatibility, a string that is the name of one of the above symbo
 Version 2020-04-09"
   (interactive (list
 		        (widget-prompt-value (get 'xah-fly-key-current-layout 'custom-type)
-				                     "New keyboard layout:")))
-  (setq xah-fly-key-current-layout @layout)
-  ;; (load "xah-fly-keys")
-  )
+				                     "New keyboard layout: ")))
+  (funcall (get 'xah-fly-key-current-layout 'custom-set)
+	   'xah-fly-key-current-layout
+	   @layout))
 
 (defun xah-fly-command-mode-init ()
   "Set command mode keys.

--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -3295,6 +3295,7 @@ command and insert modes in `xah-fly-shared-map'."
 Define keys that are available in both command and insert modes here, like
 `xah-fly-mode-toggle'")
 
+;; (cons 'keymap xah-fly-shared-map) makes a new keymap with `xah-fly-shared-map' as its parent. See info node (elisp)Inheritance and Keymaps.
 (defvar xah-fly-command-map (cons 'keymap xah-fly-shared-map)
   "Keymap that takes precedence over all other keymaps in command mode.
 


### PR DESCRIPTION
 Hey Xah,

Saw your notes in your blog and think I figured out why the recursive-load was happening: because of the way the Customize interface works, it tries to use the setter (same as the `custom-set` property) to set the default value. However, the setter is `xah-fly-keys-set-layout`, which reloads the file to update the keybindings to the new layout. Loading the file again calls the setter again which reloads the file, etc which causes the recursive load.

I've fixed this by not making the Customize interface dependent on `xah-fly-keys-set-layout` and only have it reload the file if it was already loaded and the new value is different than the old one. Otherwise, the bindings will not be updated to use the new layout when people set the layout through Customize. (Also removed the extra quote I added for the Customize choices)

`xah-fly-keys-set-layout` just calls the same function that Customize would have, for people who don’t like the Customize interface or just want to do it lisp-only. The `widget-prompt-value` just asks the human-friendly names for the keyboard layouts during completion, but it will never be called for users who don’t call `xah-fly-keys-set-layout` interactively.

Note: doing `(setq xah-fly-key-current-layout 'qwerty)` before it is loaded is the same as calling `xah-fly-keys-set-layout` after it is loaded, and will speed up your init slightly since the file will only be loaded once.

---

As for the isearch: I think your solution with the isearch hooks is a good one, since isearch only tries to be careful if a transient map is started during isearch, but it replaces any maps that were there before it. This is bad behavior on the part of isearch (and I might try to make a change to upstream Emacs to convert it to `set-transient-keymap` too :smile:), but for now it is ok to use the hooks since isearch is an exception to how modes should interact.