### PR TITLE
Integration mechanism for other major modes

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -4083,6 +4083,32 @@ Version 2018-05-07"
       (xah-fly-command-mode-activate)
     (xah-fly-insert-mode-activate)))
 
+(defun xah-fly-one-command-2 ()
+  "Internal function."
+  ;; Re-enter command-mode, unless a different transient map has been set in the meantime or we entered a minibuffer.
+  (unless (and overriding-terminal-local-map
+	       xah-fly-insert-state-q)
+    (remove-hook 'post-command-hook #'xah-fly-one-command-2)
+    (when (and xah-fly-insert-state-q
+	       (not (minibufferp)))
+      (xah-fly-command-mode-activate))))
+
+(defun xah-fly-one-command-1 ()
+  "Internal function."
+  ;; Register a hook to possibly re-enable command mode after the next function completes.
+  (remove-hook 'post-command-hook #'xah-fly-one-command-1)
+  (add-hook 'post-command-hook #'xah-fly-one-command-2))
+
+(defun xah-fly-one-command ()
+  "Go into insert mode for the duration of one command.
+
+Very useful for utilizing both Xah Fly Keys' fast navigation commands and
+a mode's own keymaps.
+Version 2020-05-11"
+  (interactive)
+  (xah-fly-insert-mode-activate)
+  (add-hook 'post-command-hook #'xah-fly-one-command-1))
+
 (defun xah-fly-save-buffer-if-file ()
   "Save current buffer if it is a file."
   (interactive)


### PR DESCRIPTION
I've come up with a nice way to integrate both a mode's existing keymaps with xfk that helps me, sending a PR so other people can also benefit:

The `xah-fly-one-command` function basically enables insert-mode for the duration of one command, then re-enables command mode at the end of the function. I like to bind it to DEL in command-mode, so it's basically like all the old mode bindings are accessible thru the leader key DEL.

For example, Magit's "c c" to commit -> "DEL c c" in command-mode. Useful for things like Magit and PDF Tools. Other users can choose to bind it to something else like a function key in command-mode