### PR TITLE
Support for newer mod dh with m on the home row

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following keyboard layouts are supported:
 * "azerty-be"
 * "colemak"
 * "colemak-mod-dh"
+* "colemak-mod-dh-iso"
 * "dvorak"
 * "programer-dvorak"
 * "qwerty"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following keyboard layouts are supported:
 * "azerty-be"
 * "colemak"
 * "colemak-mod-dh"
-* "colemak-mod-dh-iso"
+* "colemak-mod-dh-new"
 * "dvorak"
 * "programer-dvorak"
 * "qwerty"

--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -35,6 +35,7 @@
 ;; azerty-be
 ;; colemak
 ;; colemak-mod-dh
+;; colemak-mod-dh-iso
 ;; dvorak
 ;; programer-dvorak
 ;; qwerty
@@ -3014,6 +3015,39 @@ Version 2017-01-29"
     ("z" . "/"))
   "A alist, each element is of the form(\"e\" . \"d\"). First char is Dvorak, second is corresponding Colemak Mod-DH layout. Not all chars are in the list, such as digits. When not in this alist, they are assumed to be the same.")
 
+(defvar xah--dvorak-to-colemak-mod-dh-iso-kmap
+  '(("'" . "q")
+    ("," . "w")
+    ("." . "f")
+    ("p" . "p")
+    ("y" . "b")
+    ("f" . "j")
+    ("g" . "l")
+    ("c" . "u")
+    ("r" . "y")
+    ("l" . ";")
+    ("a" . "a")
+    ("o" . "r")
+    ("e" . "s")
+    ("u" . "t")
+    ("i" . "g")
+    ("d" . "m")
+    ("h" . "n")
+    ("t" . "e")
+    ("n" . "i")
+    ("s" . "o")
+    (";" . "x")
+    ("q" . "c")
+    ("j" . "d")
+    ("k" . "v")
+    ("x" . "\\")
+    ("b" . "k")
+    ("m" . "h")
+    ("w" . ",")
+    ("v" . ".")
+    ("z" . "/"))
+  "A alist, each element is of the form(\"e\" . \"d\"). First char is Dvorak, second is corresponding Colemak Mod-DH layout. Not all chars are in the list, such as digits. When not in this alist, they are assumed to be the same.")
+
 (defvar xah--dvorak-to-dvorak-kmap
   '()
   "A alist, dvorak to dvorak.")
@@ -3443,6 +3477,7 @@ If the value is nil, it's automatically set to \"dvorak\"."
                   (const :tag "Belgian AZERTY" azerty-be)
                   (const :tag "Colemak" colemak)
                   (const :tag "Colemak Mod-DH" colemak-mod-dh)
+		  (const :tag "Colemak Mod-DH for ISO" colemak-mod-dh-iso)
                   (const :tag "Dvorak" dvorak)
                   (const :tag "Programmer Dvorak" programer-dvorak)
                   (const :tag "QWERTY" qwerty)
@@ -4221,6 +4256,7 @@ Argument must be one of:
  'azerty-be
  'colemak
  'colemak-mod-dh
+ 'colemak-mod-dh-iso
  'dvorak
  'programer-dvorak
  'qwerty

--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -35,7 +35,7 @@
 ;; azerty-be
 ;; colemak
 ;; colemak-mod-dh
-;; colemak-mod-dh-iso
+;; colemak-mod-dh-new
 ;; dvorak
 ;; programer-dvorak
 ;; qwerty
@@ -3015,7 +3015,7 @@ Version 2017-01-29"
     ("z" . "/"))
   "A alist, each element is of the form(\"e\" . \"d\"). First char is Dvorak, second is corresponding Colemak Mod-DH layout. Not all chars are in the list, such as digits. When not in this alist, they are assumed to be the same.")
 
-(defvar xah--dvorak-to-colemak-mod-dh-iso-kmap
+(defvar xah--dvorak-to-colemak-mod-dh-new-kmap
   '(("'" . "q")
     ("," . "w")
     ("." . "f")
@@ -3477,7 +3477,7 @@ If the value is nil, it's automatically set to \"dvorak\"."
                   (const :tag "Belgian AZERTY" azerty-be)
                   (const :tag "Colemak" colemak)
                   (const :tag "Colemak Mod-DH" colemak-mod-dh)
-		  (const :tag "Colemak Mod-DH for ISO" colemak-mod-dh-iso)
+		  (const :tag "New Colemak Mod-DH with M on the home row" colemak-mod-dh-new)
                   (const :tag "Dvorak" dvorak)
                   (const :tag "Programmer Dvorak" programer-dvorak)
                   (const :tag "QWERTY" qwerty)
@@ -4256,7 +4256,7 @@ Argument must be one of:
  'azerty-be
  'colemak
  'colemak-mod-dh
- 'colemak-mod-dh-iso
+ 'colemak-mod-dh-new
  'dvorak
  'programer-dvorak
  'qwerty


### PR DESCRIPTION
The colemak mod dh files from [colemakmods](https://github.com/ColemakMods/mod-dh) have switched over to a version with m on the home row. I have added support for this layout, with the name "mod-dh-new". The pr uses the version where the iso key is used for the letter z, although that doesn't affect keys which xah-fly-keys uses.