### PR TITLE
Support visual-line-mode in xah-select-line

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -1990,12 +1990,23 @@ URL `http://ergoemacs.org/emacs/modernization_mark-word.html'
 Version 2017-11-01"
   (interactive)
   (if (region-active-p)
+      (if visual-line-mode
+          (let (($point (point)))
+                ;; Advance to end of current line first
+                (end-of-visual-line 1)
+                ;; If we were at end of line, advance to next line's end
+                (when (equal $point (point))
+                  (end-of-visual-line 2)))
+        (progn
+          (forward-line 1)
+          (end-of-line)))
+    (if visual-line-mode
+        (progn (beginning-of-visual-line)
+               (set-mark (point))
+               (end-of-visual-line))
       (progn
-        (forward-line 1)
-        (end-of-line))
-    (progn
-      (end-of-line)
-      (set-mark (line-beginning-position)))))
+        (end-of-line)
+        (set-mark (line-beginning-position))))))
 
 (defun xah-extend-selection ()
   "Select the current word, bracket/quote expression, or expand selection.


### PR DESCRIPTION
When looking for a way to make `xah-select-line` work with visual lines, I found that there's no `forward-visual-line`; instead, I discovered that `end-of-visual-line` can take an optional parameter. The default behavior equals `(end-of-visual-line 1)`, but when you pass `2`, it goes to the end of the _next_ visual line.

Then I found that it was odd that the key binding does always go down 1 line first when a region is active, even if point is in the middle of a line.K  Instead, I wanted to go to the end of the line first, even with a region active, and *then* advance to the next line. I added a new branching path for that.

I left the old code untouched; but if you like that behavior, I can extend the non-visual variant to go to end-of-line first, and if it's already there, advance to the next line.

Can also remove the comments of course.

## Demonstration of the "end of line first" behavior

![2021-03-18 17 14 45](https://user-images.githubusercontent.com/59080/111659667-b5bdcf80-880d-11eb-816d-ba8659c34713.gif)

