### PR TITLE
indent-rigidly: support XFK arrow keys

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -602,7 +602,7 @@ Version 2017-07-02"
      ((looking-back "\\s\"" 1)
       (if (nth 3 (syntax-ppss))
           (progn
-            (backward-char )
+            (backward-char)
             (xah-delete-forward-bracket-pairs (not current-prefix-arg)))
         (if current-prefix-arg
             (xah-delete-backward-bracket-pair)

--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -4340,6 +4340,14 @@ minor modes loaded later may override bindings in this map.")
    ))
 
 ;; HHH___________________________________________________________________
+;; Movement key integrations with built-in Emacs packages
+
+(xah-fly--define-keys
+ indent-rigidly-map
+ '(("h" . indent-rigidly-left)
+   ("n" . indent-rigidly-right)))
+
+;; HHH___________________________________________________________________
 ;;;; misc
 
 ;; the following have keys in emacs, but right now i decided not to give them a key, because either they are rarely used (say, less than once a month by 90% of emacs users), or there is a more efficient command/workflow with key in xah-fly-keys

--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -3770,8 +3770,9 @@ Version 2020-04-18"
 
 (defmacro xah-fly--define-keys (@keymap-name @key-cmd-alist &optional @direct-q)
   "Map `define-key' over a alist @key-cmd-alist, with key layout remap.
-The key is remapped by `xah-fly--key-char'.
-If @direct-q is t, do not remap key.
+The key is remapped from Dvorak to the current keyboard layout
+by `xah-fly--key-char'.
+If @direct-q is t, do not remap key to current keyboard layout.
 Example usage:
 ;; (xah-fly--define-keys
 ;;  (define-prefix-command 'xah-fly-dot-keymap)


### PR DESCRIPTION
To be honest, I don't know if this kind of integration with other packages should be part of XFK, or rather part of the user's `init.el`. It probably doesn't scale to try to support the 'arrow keys' in the XFK command map everywhere. 

Just close the PR if you htink XFK shouldn't support that.

I split this into multiple commits in case you want to keep parts of this and want me to revert e.g. the docstring changes, or keep the docstring change and rash the indent-rigidly key mapping.

