### PR TITLE
xah-open-recently-closed: drop ido in favor of built-in completing-read

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -2111,7 +2111,7 @@ Prompt for a choice.
 URL `http://ergoemacs.org/emacs/elisp_close_buffer_open_last_closed.html'
 Version 2016-06-19"
   (interactive)
-  (find-file (ido-completing-read "open:" (mapcar (lambda (f) (cdr f)) xah-recently-closed-buffers))))
+  (find-file (completing-read "Open: " (mapcar (lambda (f) (cdr f)) xah-recently-closed-buffers))))
 
 (defun xah-list-recently-closed ()
   "List recently closed file.


### PR DESCRIPTION
1. Capitalize the "open:" and add a trailing space (as advised by the manual) -- purely taste, not sure if that's too intrusive ;)
2. Use `completing-read` instead of `ido-completing-read`: this allows the user to pick which completion style to use. 
    - When the user prefers ido, proper configuration will be having `completing-read-function` set to `ido-completing-read` anyway.
    - This makes the function instantly compatible with selectrum, vertico, etc. as well and not override user's choice