### PR TITLE
Add -indicator variables to customize the mode line

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -143,6 +143,11 @@
 (defvar xah-fly-command-mode-activate-hook nil "Hook for `xah-fly-command-mode-activate'")
 (defvar xah-fly-insert-mode-activate-hook nil "Hook for `xah-fly-insert-mode-activate'")
 
+(defvar xah-fly-command-mode-indicator "c"
+  "Character in mode line indicating command mode is active.")
+(defvar xah-fly-insert-mode-indicator "i"
+  "Character in mode line indicating insert mode is active.")
+
 (defcustom xah-fly-use-control-key t
   "If nil, do not bind any control key. When t, standard keys for open, close, paste, are bound."
   :type 'boolean
@@ -4326,7 +4331,7 @@ Version: 2020-04-28"
         (set-transient-map xah-fly-command-map (lambda () t)))
   (modify-all-frames-parameters (list (cons 'cursor-type 'box)))
   ;; (set-face-background 'cursor "red")
-  (setq mode-line-front-space "c")
+  (setq mode-line-front-space xah-fly-command-mode-indicator)
   (force-mode-line-update))
 
 (defun xah-fly-space-key ()
@@ -4347,7 +4352,7 @@ Version: 2018-05-07"
   (unless no-indication
     (modify-all-frames-parameters '((cursor-type . bar)))
     ;; (set-face-background 'cursor "black")
-    (setq mode-line-front-space "i"))
+    (setq mode-line-front-space xah-fly-insert-mode-indicator))
   (force-mode-line-update))
 
 (defun xah-fly-mode-toggle ()


### PR DESCRIPTION
To give users the ability to change "c" and "i" to something different. 

I found the `doom-modeline` colored mode bullets more useful to see the currently active mode, maybe because the characters are rather small (with my config).

Users can now customize the indicators including whitespace like so (random example):

    (setq xah-fly-insert-mode-indicator "● ")
    (setq xah-fly-command-mode-indicator "– ")

![Screen Shot 2022-01-12 at 22 19 18](https://user-images.githubusercontent.com/59080/149223013-64cec365-4098-4bd8-ae88-9ce286d028e8.png)

