### PR TITLE
make sure to clean up on xah-fly-command-mode-init subsequent calls

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -4591,10 +4591,12 @@ Version: 2018-05-07"
 
 (defun xah-fly-command-mode-init ()
   "Set command mode keys.
-Version: 2020-04-28"
+Version: 2022-07-06"
   (interactive)
   (setq xah-fly-insert-state-p nil)
   (xah-fly--update-key-map)
+  (when xah-fly--deactivate-command-mode-func
+    (funcall xah-fly--deactivate-command-mode-func))
   (setq xah-fly--deactivate-command-mode-func
         (set-transient-map xah-fly-command-map (lambda () t)))
   (modify-all-frames-parameters (list (cons 'cursor-type 'box)))
@@ -4705,14 +4707,6 @@ URL `http://xahlee.info/emacs/misc/xah-fly-keys.html'"
 
       ;;
       )))
-
-(when (= emacs-major-version 28)
-  ;; 2022-06-14 fix a emacs 28.1 bug.
-  ;; clear-transient-map bug
-  ;; http://xahlee.info/emacs/emacs/clear-transient-map_bug.html
-  (progn
-    (defun xah-clear-pre-command-hook () (setq pre-command-hook nil))
-    (add-hook 'xah-fly-insert-mode-activate-hook 'xah-clear-pre-command-hook)))
 
 (provide 'xah-fly-keys)
 


### PR DESCRIPTION
`xah-fly-command-mode-init` uses a feature of the `set-transient-map`
that explicitly disables a clean up on a pre-command-hook
invocation (`keep-pred` parameter):

```
(setq xah-fly--deactivate-command-mode-func
        (set-transient-map xah-fly-command-map (lambda () t)))
```

In our case it is `(lambda () t)`.

From the code of the `set-transient-map`:

```
However, if the optional argument KEEP-PRED is t, MAP stays
active if a key from MAP is used.  KEEP-PRED can also be a
function of no arguments: it is called from `pre-command-hook' and
if it returns non-nil, then MAP stays active.
```

Although `xah-fly-command-map` map stays active until insert mode is
started (as it should be since we don't want quite a command mode
prematurely) and XFK takes responsibility of invoking the cleanup
function (`xah-fly--deactivate-command-mode-func`) when insert mode is
activated, `xah-fly-command-mode-init` could be called multiple times.

Subsequent activation of the command mode overwrites
`xah-fly--deactivate-command-mode-func`, meaning that we loose a
reference to a clean up func that is supposed to remove the
`clear-transient-map` items from the `pre-command-hook`.

This commit ensures that a subsequent command mode activation clears
up a transient map set by already active command mode.

Closes #145