### PR TITLE
`xah-beginning-of-line-or-block': tabs/spaces

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -4,7 +4,7 @@
 
 ;; Author: Xah Lee ( http://xahlee.info/ )
 ;; Maintainer: Xah Lee <xah@xahlee.org>
-;; Version: 17.15.20220705140319
+;; Version: 17.15.20220706180000
 ;; Created: 10 Sep 2013
 ;; Package-Requires: ((emacs "24.1"))
 ;; Keywords: convenience, emulations, vim, ergoemacs
@@ -216,13 +216,13 @@ Version: 2016-04-04"
 • if `visual-line-mode' is on, beginning of line means visual line.
 
 URL `http://xahlee.info/emacs/emacs/emacs_keybinding_design_beginning-of-line-or-block.html'
-Version: 2018-06-04 2021-03-16 2022-03-30 2022-07-03"
+Version: 2018-06-04 2021-03-16 2022-03-30 2022-07-03 2022-07-06"
   (interactive)
   (let (($p (point)))
     (if (or (equal (point) (line-beginning-position))
             (eq last-command this-command))
         (when
-            (re-search-backward "\n\n+" nil 1)
+            (re-search-backward "\n[\t\n ]*\n+" nil 1)
           (skip-chars-backward "\n\t ")
           (forward-char))
       (if visual-line-mode


### PR DESCRIPTION
Don't skip over tabs/spaces, when they are the only things on that line.

This shows why I think it should be like this.  Have your cursor under "Fifth line." and run `xah-beginning-of-line-or-block'.  The cursor will now move under "First line.", skipping all the lines in between.
```
First line.

Second line.
     
	Third line.
 
    Forth line.
	
Fifth line.

```