### PR TITLE
Make sure xah-delete-current-text-block doesn't delete two text blocks

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -1677,7 +1677,7 @@ Version: 2017-07-09 2023-06-07 2023-10-09"
           (setq xp1 (point)))
         (skip-chars-forward " \n\t")
         (if (re-search-forward "\n[ \t]*\n+" nil :move)
-            (setq xp2 (match-end 0))
+            (setq xp2 (match-beginning 0))
           (setq xp2 (point-max)))))
     (kill-region xp1 xp2)))
 


### PR DESCRIPTION
Hey xah!

Continuing thread from https://github.com/xahlee/xah-fly-keys/commit/7118846cda6026acd12a3fc6ab52a70091e6ec1a#commitcomment-130745305 here

I'm on emacs 29.1, and for me if I have

```
aaaaaaaaaa
bbbbbbbbbb

cccccccccc|
dddddddddd

eeeeeeeeee
ffffffffff
```
(`|` represents point, not a character)

and I do `xah-delete-current-text-block`, I end up with

```
aaaaaaaaaa
bbbbbbbbbb|eeeeeeeeee
ffffffffff
```

I assume this is not intended behavior because like @ckeschnat said, it means doing `xah-delete-current-text-block` twice will actually delete 3 text blocks.

Had some time to step through it with edebug and this is what's happening on my machine:

1. Starting out like this:
  ```
aaaaaaaaaa
bbbbbbbbbb

cccccccccc|
dddddddddd

eeeeeeeeee
ffffffffff
```
2. Then I do `xah-delete-current-text-block`. `(re-search-backward "\n[ \t]*\n+" nil :move)` runs and both point and `xp1` ends up here:

```
aaaaaaaaaa
bbbbbbbbbb|

cccccccccc
dddddddddd

eeeeeeeeee
ffffffffff
```

3. `(skip-chars-forward " \n\t")` runs and point ends up here:
```
aaaaaaaaaa
bbbbbbbbbb

|cccccccccc
dddddddddd

eeeeeeeeee
ffffffffff
```

4. `(re-search-forward "\n[ \t]*\n+" nil :move)` runs and both point and `xp2` end up here:

```
aaaaaaaaaa
bbbbbbbbbb

cccccccccc
dddddddddd

|eeeeeeeeee
ffffffffff
```

5. `(kill-region xp1 xp2)` runs and this is the result:

```
aaaaaaaaaa
bbbbbbbbbb|eeeeeeeeee
ffffffffff
```
<hr>

I changed step 4 to go to `match-beginning` instead so it would leave the next two lines alone and the surrounding text blocks don't get merged:

```
aaaaaaaaaa
bbbbbbbbbb

cccccccccc
dddddddddd|

eeeeeeeeee
ffffffffff
```

This way, if point is in the middle of a bunch of blank lines, it will still reliably delete the next text block like you want, but will leave any lines after that alone. What do you think ?