### PR TITLE
Add qwerty-se (Swedish) layout

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -131,6 +131,7 @@
 ;; qwerty
 ;; qwerty-abnt (Brazil)
 ;; qwerty-no (Norwegian)
+;; qwerty-se (Swedish)
 ;; qwertz
 ;; qwpr
 ;; russian
@@ -3183,6 +3184,19 @@ z x c v b n m , . -
 
 Q W E R T Y U I O P Å ^ *
 A S D F G H J K L Ø Æ
+Z X C V B N M < > _
+" xah-fly-layout-diagrams)
+
+  (puthash "qwerty-se" "
+§ ! \" # ¤ % & / ( ) = ? `
+| 1  2 3 4 5 6 7 8 9 0 + \\
+
+q w e r t y u i o p å ¨ '
+a s d f g h j k l ö ä
+z x c v b n m , . -
+
+Q W E R T Y U I O P Å ^ *
+A S D F G H J K L Ö Ä
 Z X C V B N M < > _
 " xah-fly-layout-diagrams)
 


### PR DESCRIPTION
Add the standard Swedish QWERTY layout as 'qwerty-se'.